### PR TITLE
Redesign changelog affecting part

### DIFF
--- a/.changelogged.template.yaml
+++ b/.changelogged.template.yaml
@@ -15,6 +15,10 @@ changelogs:
     # watch all files except for the changelog itself
     ignore_files:
       - ChangeLog.md
+    
+    # which individual changes to ignore
+    #
+    # ignore_commits: []
 
     # which files to modify when performing a regular version bump
     version_files:
@@ -54,6 +58,3 @@ changelogs:
 #
 # branch: master
 
-# which individual changes to ignore
-#
-# ignore_commits: []

--- a/.changelogged.yaml
+++ b/.changelogged.yaml
@@ -9,6 +9,7 @@ changelogs:
 
     ignore_files:
       - ChangeLog.md
+      - .changelogged.yaml
 
     ignore_commits: []
 

--- a/.changelogged.yaml
+++ b/.changelogged.yaml
@@ -10,6 +10,8 @@ changelogs:
     ignore_files:
       - ChangeLog.md
 
+    ignore_commits: []
+
     version_files:
       - path: package.yaml
         version_pattern:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ and also list any recent changes that are not included in you changelog.
 You can then prepend missing changelog entries automatically with
 
 ```
-changelogged --update-changelog --format suggest
+changelogged --update-changelog
 ```
 
 Now you can see new entries in your changelog, make edits and group changes.
+Even if you see simple messages on a screen, detailed (with links, see demo) are written to changelog.
 When you're done you can automatically bump project's version with
 
 ```
@@ -65,22 +66,27 @@ changelogged --help
 changelogged - Changelog Manager for Git Projects
 
 Usage: changelogged [--format FORMAT] [--update-changelog] [--bump-versions]
-
 Available options:
   -h,--help                Show this help text
-  --format FORMAT          Missing entries report format. FORMAT can be 'simple'
-                           or 'suggest'. (default: simple)
-  --update-changelog       Prepend missing entries to changelogs. Available with
-                           --format=suggest.
-  --bump-versions          Bump versions according to change level.
-  --level CHANGE_LEVEL     Level of changes (for packages). CHANGE_LEVEL can be
-                           'app', 'major', 'minor', 'fix' or 'doc'.
-  --api-level CHANGE_LEVEL Level of changes (for API). CHANGE_LEVEL can be
-                           'app', 'major', 'minor', 'fix' or 'doc'.
-  --from-bc                Check changelogs for the entire history of the
-                           project.
-  --force                  Bump versions even when changelogs are outdated.
-  --no-check               Do not check changelogs.
+  --format FORMAT          Format for missing changelog entry warnings. FORMAT
+                           can be 'simple' or 'suggest'. (default: simple)
+  --update-changelog       Add missing entries to changelogs (works with
+                           --format=suggest).
+  --bump-versions          Bump versions in version files.
+  --level CHANGE_LEVEL     Level of changes (to override one inferred from
+                           changelog). CHANGE_LEVEL can be 'app', 'major',
+                           'minor', 'fix' or 'doc'.
+  --from-bc                Look for missing changelog entries from the start of
+                           the project.
+  --force                  Bump versions ignoring possibly outdated changelogs.
+  --no-check               Do not check if changelogs have any missing entries.
+  --no-colors              Print all messages in standard terminal color.
+  --dry-run                Do not change files while running.
+  TARGET_CHANGELOG         Path to target changelog.
+  --config changelogged.yaml config file location
+                           Path to config file.
+  --verbose                Turn verbose mode on (useful for developers).
+  --version                Print version.
 ```
 
 See examples [below](#guiding-examples)
@@ -195,8 +201,6 @@ It works with Git projects only.
 It was never tested on Windows. Ideally it will work if you have Git Bash installed.
 
 ### Getting and building
-
-For now the only way to get `changelogged` is to build it from source.
 
 #### Installing from Hackage
 

--- a/src/Changelogged/Config.hs
+++ b/src/Changelogged/Config.hs
@@ -18,7 +18,6 @@ import Changelogged.Pure
 
 data Config = Config
   { configChangelogs    :: [ChangelogConfig]
-  , configIgnoreCommits :: Maybe [Text]
   , configBranch        :: Maybe Text
   } deriving (Eq, Show, Generic)
 
@@ -31,11 +30,12 @@ data LevelHeaders = LevelHeaders
   } deriving (Eq, Show, Generic)
 
 data ChangelogConfig = ChangelogConfig
-  { changelogChangelog    :: Turtle.FilePath
-  , changelogLevelHeaders :: LevelHeaders
-  , changelogWatchFiles   :: Maybe [Turtle.FilePath]
-  , changelogIgnoreFiles  :: Maybe [Turtle.FilePath]
-  , changelogVersionFiles :: Maybe [VersionFile]
+  { changelogChangelog     :: Turtle.FilePath
+  , changelogLevelHeaders  :: LevelHeaders
+  , changelogWatchFiles    :: Maybe [Turtle.FilePath]
+  , changelogIgnoreFiles   :: Maybe [Turtle.FilePath]
+  , changelogIgnoreCommits :: Maybe [Text]
+  , changelogVersionFiles  :: Maybe [VersionFile]
   } deriving (Eq, Show, Generic)
 
 data VersionPattern = VersionPattern
@@ -60,13 +60,13 @@ defaultLevelHeaders = LevelHeaders
 defaultConfig :: Config
 defaultConfig = Config
   { configChangelogs    = pure ChangelogConfig
-      { changelogChangelog    = "ChangeLog.md"
-      , changelogLevelHeaders = defaultLevelHeaders
-      , changelogWatchFiles   = Nothing  -- watch everything
-      , changelogIgnoreFiles  = Nothing  -- ignore nothing
-      , changelogVersionFiles = Just [VersionFile "package.yaml" (VersionPattern "version" ":")]
+      { changelogChangelog     = "ChangeLog.md"
+      , changelogLevelHeaders  = defaultLevelHeaders
+      , changelogWatchFiles    = Nothing  -- watch everything
+      , changelogIgnoreFiles   = Nothing  -- ignore nothing
+      , changelogIgnoreCommits = Nothing
+      , changelogVersionFiles  = Just [VersionFile "package.yaml" (VersionPattern "version" ":")]
       }
-  , configIgnoreCommits = Nothing
   , configBranch = Nothing
   }
 
@@ -80,7 +80,6 @@ loadConfig path = do
 ppConfig :: Config -> Text
 ppConfig Config{..} = mconcat
   [ "Main branch (with version tags)" ?: configBranch
-  , "Ignored commits" ?: (Text.pack . show . length <$> configIgnoreCommits)
   , "Changelogs" !: formatItems Turtle.fp (map changelogChangelog configChangelogs)
   ]
   where


### PR DESCRIPTION
Work in progress
Current coverage:
 - [ ] Refactor `eval` local function of `checkLocalChangelogF`.
 - [ ] Fix bug with ignoring and watching multiple files.
 - [ ] Use git diff-tree instead of git show as clearer.
 - [ ] Implement ignored commits (#81)
 - [ ] Ignore changes to changelog itself by default (#77).
Further coverage:
 - [ ] Refactor `processChangelog` and `checkLocalChangelogF`. (#91) These are shit now.
 - [ ] Ignore all present changelogs by default for each changelog.
 - [ ] #80 - and split further tool in two chained domains. Make list of common options, list of versioning options and list of logging options. Also this will simplify usage reference. As for git.
 - [ ] Something else

In plans there are also:
 * #82 - with `_`/`_` as structure wildcard and `__` as complete wildcard
 * #100 - Or just close it
 * #71 - now I little more know what to do, it's breaking change of usability
 * #78 - To be able to split spreading config to couple of files 
 * #105 and #60. - After I rend all the giants. #105 is crucial, #60 can wait. There are most of the problems in text manipulations.