### PR TITLE
Architecture

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,12 +7,11 @@ import Data.Text (unpack, pack)
 
 import System.Console.ANSI (Color(..))
 
-import Changelogged.EntryPoint (processChangelogs)
-import Changelogged.Git
-import Changelogged.Options
-import Changelogged.Utils
-import Changelogged.Pure (showPath, changeloggedVersion)
+import Changelogged.EntryPoint
+
+import Changelogged.Common
 import Changelogged.Config
+import Changelogged.Options
 
 prepareConfig :: FilePath -> Options -> IO Config
 prepareConfig configPath Options{..} = do

--- a/src/Changelogged/Aeson.hs
+++ b/src/Changelogged/Aeson.hs
@@ -1,0 +1,28 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE StandaloneDeriving #-}
+module Changelogged.Aeson () where
+
+import Data.Aeson (ToJSON(..), FromJSON(..))
+import Data.Aeson.TH (deriveJSON)
+
+import qualified Filesystem.Path.CurrentOS as Path
+
+import Changelogged.Common.Types
+import Changelogged.Common.Utils.Pure
+
+instance FromJSON Path.FilePath where
+  parseJSON = fmap Path.decodeString . parseJSON
+
+instance ToJSON Path.FilePath where
+  toJSON = toJSON . Path.encodeString
+
+deriving instance ToJSON Options
+
+deriveJSON (jsonDerivingModifier "VersionPattern") ''VersionPattern
+deriveJSON (jsonDerivingModifier "VersionFile") ''VersionFile
+deriveJSON (jsonDerivingModifier "LevelHeaders") ''LevelHeaders
+deriveJSON (jsonDerivingModifier "Changelog") ''ChangelogConfig
+deriveJSON (jsonDerivingModifier "Config") ''Config

--- a/src/Changelogged/Common.hs
+++ b/src/Changelogged/Common.hs
@@ -1,0 +1,7 @@
+module Changelogged.Common
+  ( module Changelogged.Common.Utils
+  , module Changelogged.Common.Types
+  ) where
+
+import Changelogged.Common.Utils
+import Changelogged.Common.Types

--- a/src/Changelogged/Common/Types.hs
+++ b/src/Changelogged/Common/Types.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Changelogged.Common.Types
+  ( module Changelogged.Common.Types.Common
+  , module Changelogged.Common.Types.Options
+  , module Changelogged.Common.Types.Config
+  , module Changelogged.Common.Types.Git
+  , module Control.Monad.Reader
+  , Appl(..)
+  , runInAppl
+  ) where
+
+import Control.Monad.Base
+import Control.Monad.Catch
+import Control.Monad.Reader
+
+import Changelogged.Common.Types.Common
+import Changelogged.Common.Types.Options
+import Changelogged.Common.Types.Config
+import Changelogged.Common.Types.Git
+
+newtype Appl a = Appl { runAppl :: ReaderT Options IO a }
+  deriving newtype (Functor, Applicative, Monad, MonadReader Options, MonadIO, MonadBase IO, MonadThrow, MonadCatch)
+
+runInAppl :: Options -> Appl a -> IO a
+runInAppl opts r = runReaderT (runAppl r) opts

--- a/src/Changelogged/Common/Types/Common.hs
+++ b/src/Changelogged/Common/Types/Common.hs
@@ -1,13 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
-module Changelogged.Types where
+module Changelogged.Common.Types.Common where
 
 import Data.Aeson
 import Data.Text (Text)
 import GHC.Generics (Generic)
-
-import qualified Filesystem.Path.CurrentOS as Path
 
 newtype SHA1 = SHA1 {getSHA1 :: Text} deriving (Eq, Show)
 newtype Link = Link {getLink :: Text} deriving (Eq, Show)
@@ -19,9 +16,6 @@ data Commit = Commit
   , commitIsPR    :: Maybe PR
   , commitSHA     :: SHA1
   } deriving (Eq, Show)
-
-instance FromJSON Path.FilePath where
-  parseJSON = fmap Path.decodeString . parseJSON
 
 -- |Level of changes to bump to.
 data Level = App | Major | Minor | Fix | Doc

--- a/src/Changelogged/Common/Types/Config.hs
+++ b/src/Changelogged/Common/Types/Config.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Changelogged.Common.Types.Config where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import qualified Filesystem.Path.CurrentOS as Path
+
+data Config = Config
+  { configChangelogs    :: [ChangelogConfig]
+  , configBranch        :: Maybe Text
+  } deriving (Eq, Show, Generic)
+
+data LevelHeaders = LevelHeaders
+  { levelHeadersApp   :: Maybe Text
+  , levelHeadersMajor :: Maybe Text
+  , levelHeadersMinor :: Maybe Text
+  , levelHeadersFix   :: Maybe Text
+  , levelHeadersDoc   :: Maybe Text
+  } deriving (Eq, Show, Generic)
+
+data ChangelogConfig = ChangelogConfig
+  { changelogChangelog     :: Path.FilePath
+  , changelogLevelHeaders  :: LevelHeaders
+  , changelogWatchFiles    :: Maybe [Path.FilePath]
+  , changelogIgnoreFiles   :: Maybe [Path.FilePath]
+  , changelogIgnoreCommits :: Maybe [Text]
+  , changelogVersionFiles  :: Maybe [VersionFile]
+  } deriving (Eq, Show, Generic)
+
+data VersionPattern = VersionPattern
+  { versionPatternVariable  :: Text
+  , versionPatternSeparator :: Text
+  } deriving (Show, Eq, Generic)
+
+data VersionFile = VersionFile
+  { versionFilePath :: Path.FilePath
+  , versionFileVersionPattern :: VersionPattern
+  } deriving (Show, Eq, Generic)

--- a/src/Changelogged/Common/Types/Git.hs
+++ b/src/Changelogged/Common/Types/Git.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Changelogged.Common.Types.Git where
+
+import Changelogged.Common.Types.Common (Link)
+
+import Turtle.Line (Line)
+import Data.Text (Text)
+
+-- | Information about the state of a git repository.
+data GitInfo = GitInfo
+  { gitHistory   :: [Line]
+    -- ^ A list of git commit messages.
+  , gitRemoteUrl :: Link
+    -- ^ An HTTP(S) link to the repository.
+    -- This will be used to construct links to issues, commits and pull requests.
+  , gitLatestVersion :: Maybe Text
+     -- ^ Latest version (tag) in the current branch. This signature avails to use git polymorphism of tags with hashes.
+  } deriving (Show)

--- a/src/Changelogged/Common/Types/Options.hs
+++ b/src/Changelogged/Common/Types/Options.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Changelogged.Common.Types.Options where
+
+import GHC.Generics (Generic)
+
+import Changelogged.Common.Types.Common
+
+import qualified Filesystem.Path.CurrentOS as Path
+
+-- | Command line options for @changelogged@.
+data Options = Options
+  { -- | Command to execute.
+    optAction          :: Maybe Action
+    -- | Format for missing changelog entry warnings.
+  , optFormat          :: WarningFormat
+    -- | Level of changes (to override one inferred from changelogs).
+  , optChangeLevel     :: Maybe Level
+    -- | Look for missing changelog entries from the start of the project.
+  , optFromBC          :: Bool
+    -- | Bump versions ignoring possibly outdated changelogs.
+  , optForce           :: Bool
+    -- | Do not check if changelogs have any missing entries.
+  , optNoCheck         :: Bool
+    -- | Print all texts in standard terminal color.
+  , optNoColors        :: Bool
+    -- | Expand PRs while suggesting and writing to changelog.
+  , optExpandPR        :: Bool
+    -- | Run avoiding changes in files.
+  , optDryRun          :: Bool
+    -- | Check exactly one target changelog.
+  , optTargetChangelog :: Maybe Path.FilePath
+    -- | Use specified config file.
+  , optConfigPath      :: Maybe Path.FilePath
+    -- | Verbosity level.
+  , optVerbose         :: Bool
+    -- | Print version.
+  , optVersion         :: Bool
+  } deriving (Generic, Show)

--- a/src/Changelogged/Common/Utils.hs
+++ b/src/Changelogged/Common/Utils.hs
@@ -1,0 +1,7 @@
+module Changelogged.Common.Utils
+  ( module Changelogged.Common.Utils.Pure
+  , module Changelogged.Common.Utils.IO
+  ) where
+
+import Changelogged.Common.Utils.Pure
+import Changelogged.Common.Utils.IO

--- a/src/Changelogged/Common/Utils/IO.hs
+++ b/src/Changelogged/Common/Utils/IO.hs
@@ -1,4 +1,4 @@
-module Changelogged.Utils where
+module Changelogged.Common.Utils.IO where
 
 import Control.Monad (when)
 import Data.Aeson (ToJSON)
@@ -12,9 +12,7 @@ import System.Console.ANSI
 
 import Turtle.Format
 
-import Changelogged.Git (getCommitTag)
-import Changelogged.Types
-import Changelogged.Options
+import Changelogged.Common.Types
 
 -- |Print '@text@' with ansi-terminal color.
 coloredPrint :: Color -> Text -> Appl ()
@@ -59,8 +57,3 @@ debugYaml title val = debug (title <> "\n" <> Text.decodeUtf8 (Yaml.encode val))
 versionP :: Version -> Appl ()
 versionP (Version ver) = coloredPrint Green $
   "VERSION: " <> ver <> "\n"
-
-printTag :: SHA1 -> Appl ()
-printTag sha = getCommitTag sha >>= \tag -> case tag of
-  Nothing -> return ()
-  Just t -> coloredPrint Yellow (t <> "\n")

--- a/src/Changelogged/Common/Utils/Pure.hs
+++ b/src/Changelogged/Common/Utils/Pure.hs
@@ -1,6 +1,7 @@
-module Changelogged.Pure where
+module Changelogged.Common.Utils.Pure where
 
-import Data.Aeson (Options(..), defaultOptions)
+import Data.Aeson
+
 import Prelude hiding (FilePath)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -10,7 +11,7 @@ import Data.List
 
 import Filesystem.Path.CurrentOS (encodeString, FilePath)
 
-import Changelogged.Types
+import Changelogged.Common.Types.Common
 
 changeloggedVersion :: Version
 changeloggedVersion = Version "0.3.0"

--- a/src/Changelogged/Config.hs
+++ b/src/Changelogged/Config.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 module Changelogged.Config where
 
-import Data.Aeson.TH
 import Data.Either.Combinators (rightToMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text)
@@ -10,43 +7,9 @@ import qualified Data.Text as Text
 import qualified Data.Yaml as Yaml
 
 import qualified Turtle
-import GHC.Generics
 
-import Changelogged.Types ()
-import Changelogged.Utils ()
-import Changelogged.Pure
-
-data Config = Config
-  { configChangelogs    :: [ChangelogConfig]
-  , configBranch        :: Maybe Text
-  } deriving (Eq, Show, Generic)
-
-data LevelHeaders = LevelHeaders
-  { levelHeadersApp   :: Maybe Text
-  , levelHeadersMajor :: Maybe Text
-  , levelHeadersMinor :: Maybe Text
-  , levelHeadersFix   :: Maybe Text
-  , levelHeadersDoc   :: Maybe Text
-  } deriving (Eq, Show, Generic)
-
-data ChangelogConfig = ChangelogConfig
-  { changelogChangelog     :: Turtle.FilePath
-  , changelogLevelHeaders  :: LevelHeaders
-  , changelogWatchFiles    :: Maybe [Turtle.FilePath]
-  , changelogIgnoreFiles   :: Maybe [Turtle.FilePath]
-  , changelogIgnoreCommits :: Maybe [Text]
-  , changelogVersionFiles  :: Maybe [VersionFile]
-  } deriving (Eq, Show, Generic)
-
-data VersionPattern = VersionPattern
-  { versionPatternVariable  :: Text
-  , versionPatternSeparator :: Text
-  } deriving (Show, Eq, Generic)
-
-data VersionFile = VersionFile
-  { versionFilePath :: Turtle.FilePath
-  , versionFileVersionPattern :: VersionPattern
-  } deriving (Show, Eq, Generic)
+import Changelogged.Common
+import Changelogged.Aeson ()
 
 defaultLevelHeaders :: LevelHeaders
 defaultLevelHeaders = LevelHeaders
@@ -88,9 +51,3 @@ ppConfig Config{..} = mconcat
 
     _    ?: Nothing = ""
     name ?: Just val = name !: val
-
-deriveJSON (jsonDerivingModifier "VersionPattern") ''VersionPattern
-deriveJSON (jsonDerivingModifier "VersionFile") ''VersionFile
-deriveJSON (jsonDerivingModifier "LevelHeaders") ''LevelHeaders
-deriveJSON (jsonDerivingModifier "Changelog") ''ChangelogConfig
-deriveJSON (jsonDerivingModifier "Config") ''Config

--- a/src/Changelogged/Options.hs
+++ b/src/Changelogged/Options.hs
@@ -1,42 +1,23 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Changelogged.Options
-  ( module Control.Monad.Reader,
-
-    Appl(..),
-    runInAppl,
-    Options(..),
+  ( Options(..),
     parseOptions
   ) where
 
-import Control.Monad.Base
-import Control.Monad.Catch
-import Control.Monad.Reader
-
-import Data.Aeson (ToJSON(..))
 import Data.Char (toLower)
 import Data.List (intercalate)
 import Data.Monoid ((<>))
 import Data.String.Conversions (cs)
-import GHC.Generics (Generic)
 
 import Options.Applicative
 import qualified Turtle
 
 import Filesystem.Path.CurrentOS (valid, fromText)
 
-import Changelogged.Types
-import Changelogged.Pure (hyphenate)
-
-newtype Appl a = Appl { runAppl :: ReaderT Options IO a }
-  deriving newtype (Functor, Applicative, Monad, MonadReader Options, MonadIO, MonadBase IO, MonadThrow, MonadCatch)
-
-runInAppl :: Options -> Appl a -> IO a
-runInAppl opts r = runReaderT (runAppl r) opts
+import Changelogged.Common
 
 -- |
 -- >>> availableWarningFormats
@@ -177,39 +158,6 @@ parser = Options
 
 welcome :: Turtle.Description
 welcome = Turtle.Description "changelogged - Changelog Manager for Git Projects"
-
--- | Command line options for @changelogged@.
-data Options = Options
-  { -- | Command to execute.
-    optAction          :: Maybe Action
-    -- | Format for missing changelog entry warnings.
-  , optFormat          :: WarningFormat
-    -- | Level of changes (to override one inferred from changelogs).
-  , optChangeLevel     :: Maybe Level
-    -- | Look for missing changelog entries from the start of the project.
-  , optFromBC          :: Bool
-    -- | Bump versions ignoring possibly outdated changelogs.
-  , optForce           :: Bool
-    -- | Do not check if changelogs have any missing entries.
-  , optNoCheck         :: Bool
-    -- | Print all texts in standard terminal color.
-  , optNoColors        :: Bool
-    -- | Expand PRs while suggesting and writing to changelog.
-  , optExpandPR        :: Bool
-    -- | Run avoiding changes in files.
-  , optDryRun          :: Bool
-    -- | Check exactly one target changelog.
-  , optTargetChangelog :: Maybe Turtle.FilePath
-    -- | Use specified config file.
-  , optConfigPath      :: Maybe Turtle.FilePath
-    -- | Verbosity level.
-  , optVerbose         :: Bool
-    -- | Print version.
-  , optVersion         :: Bool
-  } deriving (Generic, Show, ToJSON)
-
-instance ToJSON Turtle.FilePath where
-  toJSON = toJSON . Turtle.format Turtle.fp
 
 -- | Parse command line options.
 parseOptions :: IO Options

--- a/src/Changelogged/Pattern.hs
+++ b/src/Changelogged/Pattern.hs
@@ -5,7 +5,7 @@ import Turtle.Pattern
 import Turtle ((<>), (<|>))
 import Data.Text (Text, intercalate)
 
-import Changelogged.Pure
+import Changelogged.Common
 
 -- >>> match versionExactRegex "version:   1.1.1"
 -- []

--- a/src/Changelogged/Pure.hs
+++ b/src/Changelogged/Pure.hs
@@ -21,6 +21,7 @@ maxByLen [] = Nothing
 maxByLen hs = Just $ foldl1 (\left right -> if Text.length left > Text.length right then left else right) hs
 
 -- |'@fromJust@' function with custom error message.
+-- should be used in cases where 'Nothing' cannot happen with consistent input data.
 fromJustCustom :: String -> Maybe a -> a
 fromJustCustom msg Nothing = error msg
 fromJustCustom _ (Just a) = a

--- a/src/Changelogged/Versions/Bump.hs
+++ b/src/Changelogged/Versions/Bump.hs
@@ -15,12 +15,8 @@ import Filesystem.Path.CurrentOS (encodeString)
 import System.Console.ANSI (Color(..))
 
 import Changelogged.Versions.Utils
-import Changelogged.Types
-import Changelogged.Options
-import Changelogged.Utils
-import Changelogged.Pure
+import Changelogged.Common
 import Changelogged.Pattern
-import Changelogged.Config
 
 -- |Get current version.
 currentVersion :: VersionFile -> Appl Version

--- a/src/Changelogged/Versions/Utils.hs
+++ b/src/Changelogged/Versions/Utils.hs
@@ -11,9 +11,7 @@ import qualified Data.List as List
 
 import Filesystem.Path.CurrentOS (encodeString)
 
-import Changelogged.Config
-import Changelogged.Types
-import Changelogged.Options
+import Changelogged.Common
 import Changelogged.Pattern
 
 -- |Add version label to changelog.


### PR DESCRIPTION
Closes #112 
Structure:
Main is common entry point.
It imports EntryPoint, Config and Options which are imported exclusively.
Git and Pattern are domain-specific modules, they are imported in functional modules and in them only.
EntryPoint is the only module with access both to Versions and Changelog.
Inside Common (could be imported everywhere) there are Types and Utils. Utils can import Types.
Further work: Accurately split Versions and Changelog to have e.g. Changelogged.Versions which is imported only in EntryPoint and imports own submodules. Issue: #113