### PR TITLE
Enable completion of all options for Bash 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@
 
 You're encouraged to use `changelogged` when preparing a new release of your project.
 
+If you're using bash you probably want to enable autocompletion. You can do it with the following or equivalent:
+```
+changelogged --bash-completion-script `which changelogged` > changelogged
+sudo mv changelogged > /etc/bash_completion.d/
+```
+In new terminal sessions you will have it.
+
 For most projects you can start by simply running `changelogged` with no options or configuration files:
 
 ```

--- a/src/Changelogged/Changelog/Check.hs
+++ b/src/Changelogged/Changelog/Check.hs
@@ -80,9 +80,9 @@ changelogIsUp repoUrl commit@Commit{..} changelog = do
     then do
       -- If --from-bc option invoked it will prepend list of misses with version tag.
       printCommitTag commitSHA
-      case optFormat of
-        WarnSimple  -> warnMissing commit
-        WarnSuggest -> suggestMissing repoUrl commit
+      if optSuggest
+        then suggestMissing repoUrl commit
+        else warnMissing commit
       when (optAction == Just UpdateChangelogs) $ addMissing repoUrl commit changelog
       return False
     else return True

--- a/src/Changelogged/Common/Types/Common.hs
+++ b/src/Changelogged/Common/Types/Common.hs
@@ -24,12 +24,3 @@ data Level = App | Major | Minor | Fix | Doc
 -- |Available altenative actions
 data Action = UpdateChangelogs | BumpVersions
   deriving (Generic, Eq, Show, Enum, Bounded, ToJSON)
-
-data WarningFormat
-  = WarnSimple
-  | WarnSuggest
-  deriving (Generic, Eq, Enum, Bounded, ToJSON)
-
-instance Show WarningFormat where
-  show WarnSimple  = "simple"
-  show WarnSuggest = "suggest"

--- a/src/Changelogged/Common/Types/Options.hs
+++ b/src/Changelogged/Common/Types/Options.hs
@@ -11,11 +11,11 @@ import qualified Filesystem.Path.CurrentOS as Path
 data Options = Options
   { -- | Command to execute.
     optAction          :: Maybe Action
-    -- | Format for missing changelog entry warnings.
-  , optFormat          :: WarningFormat
-    -- | Level of changes (to override one inferred from changelogs).
+    -- | Format missing changelog entry warnings as suggestion writtable to changelog.
   , optChangeLevel     :: Maybe Level
     -- | Look for missing changelog entries from the start of the project.
+  , optSuggest         :: Bool
+    -- | Level of changes (to override one inferred from changelogs).
   , optFromBC          :: Bool
     -- | Bump versions ignoring possibly outdated changelogs.
   , optForce           :: Bool

--- a/src/Changelogged/Options.hs
+++ b/src/Changelogged/Options.hs
@@ -13,11 +13,12 @@ import Data.Monoid ((<>))
 import Data.String.Conversions (cs)
 
 import Options.Applicative
-import qualified Turtle
 
-import Filesystem.Path.CurrentOS (valid, fromText)
+import Prelude hiding (FilePath)
+import Filesystem.Path.CurrentOS
 
-import Changelogged.Common
+import Changelogged.Common.Types
+import Changelogged.Common.Utils.Pure
 
 -- |
 -- >>> availableWarningFormats
@@ -94,7 +95,7 @@ readAction = eitherReader (r . map toLower)
          "Unknown command: " <> show cmd <> ".\n"
       <> "Should be " <> availableActionsStr <> ".\n"
 
-readFilePath :: ReadM Turtle.FilePath
+readFilePath :: ReadM FilePath
 readFilePath = eitherReader r
   where
     r filePathString = if valid $ fromText $ cs filePathString
@@ -129,6 +130,7 @@ parser = Options
 
     changeloggedAction = argument readAction $
          metavar "ACTION"
+      <> completeWith ["update-changelog","bump-versions"]
       <> help ("If present could be update-changelog or bump-versions.")
 
     changesLevel = option readLevel $
@@ -156,9 +158,9 @@ parser = Options
       <> metavar "changelogged.yaml config file location"
       <> help ("Path to config file.")
 
-welcome :: Turtle.Description
-welcome = Turtle.Description "changelogged - Changelog Manager for Git Projects"
-
 -- | Parse command line options.
 parseOptions :: IO Options
-parseOptions = Turtle.options welcome parser
+parseOptions = execParser $ info (helper <*> parser)
+    ( fullDesc
+   <> progDesc "Changelogged"
+   <> header "Changelog Manager for Git Projects")

--- a/src/Changelogged/Options.hs
+++ b/src/Changelogged/Options.hs
@@ -21,27 +21,6 @@ import Changelogged.Common.Types
 import Changelogged.Common.Utils.Pure
 
 -- |
--- >>> availableWarningFormats
--- [simple,suggest]
-availableWarningFormats :: [WarningFormat]
-availableWarningFormats = [minBound..maxBound]
-
--- |
--- >>> availableWarningFormatsStr
--- "'simple' or 'suggest'"
-availableWarningFormatsStr :: String
-availableWarningFormatsStr = prettyPossibleValues availableWarningFormats
-
-readWarningFormat :: ReadM WarningFormat
-readWarningFormat = eitherReader (r . map toLower)
-  where
-    r "simple"  = Right WarnSimple
-    r "suggest" = Right WarnSuggest
-    r fmt = Left $
-         "Unknown warning format: " <> show fmt <> ".\n"
-      <> "Use one of " <> availableWarningFormatsStr <> ".\n"
-
--- |
 -- >>> availableLevels
 -- [App,Major,Minor,Fix,Doc]
 availableLevels :: [Level]
@@ -105,10 +84,9 @@ readFilePath = eitherReader r
 parser :: Parser Options
 parser = Options
   <$> optional changeloggedAction
-  <*> warningFormat
   <*> optional changesLevel
-  <*> hiddenSwitch "from-bc"
-        "Look for missing changelog entries from the start of the project."
+  <*> hiddenSwitch "suggest" "Format printed missing entries as writtable suggestions for ChangeLog"
+  <*> hiddenSwitch "from-bc" "Look for missing changelog entries from the start of the project."
   <*> hiddenSwitch "force" "Bump versions ignoring possibly outdated changelogs. Usable with bump-versions only"
   <*> hiddenSwitch "no-check" "Do not check if changelogs have any missing entries."
   <*> hiddenSwitch "no-colors" "Print all messages in standard terminal color."
@@ -141,13 +119,6 @@ parser = Options
            , "CHANGE_LEVEL can be " <> availableLevelsStr <> "."
            ])
       <> hidden
-    
-    warningFormat = option readWarningFormat $
-         long "format"
-      <> metavar "FORMAT"
-      <> help ("Format for missing changelog entry warnings. FORMAT can be " <> availableWarningFormatsStr <> ".")
-      <> value WarnSimple
-      <> showDefault
     
     targetChangelog = argument readFilePath $
          metavar "TARGET_CHANGELOG"


### PR DESCRIPTION
Closes #86 
`--format` option is removed since we do not write simple entries to changelogs and anyway it's unworthy to make user choose between some strictly predefined formats. Arisen issue: #115. This new formatting string will not affect default printed lines (simplest sensible form). Also it's impossible to autocomplete values after `format=`. It's not very convenient.
