### PR TITLE
Leave single action and bump versions after check

### DIFF
--- a/.changelogged.template.yaml
+++ b/.changelogged.template.yaml
@@ -66,3 +66,6 @@ changelogs:
 
 # Format of entries going to be added to changelogs
 # entry_format: "  - %message% (see [%link%](%id%));"
+
+# Text editor command to run for editing changelog.
+# editor_command: "nano -i"

--- a/.changelogged.yaml
+++ b/.changelogged.yaml
@@ -29,3 +29,5 @@ changelogs:
 branch: origin/master
 
 entry_format: "  - %message% (see [%link%](%id%));"
+
+editor_command: "nano -EiT 2"

--- a/src/Changelogged/Changelog/Check.hs
+++ b/src/Changelogged/Changelog/Check.hs
@@ -58,6 +58,6 @@ dealWithCommit GitInfo{..} ChangelogConfig{..} commitSHA = do
     commitIsPR <- fmap (PR . fromJustCustom "Cannot find commit hash in git log entry" . githubRefMatch . lineToText) <$>
         fold (grep githubRefGrep (grep (has (text (getSHA1 commitSHA))) (select gitHistory))) Fold.head
     commitMessage <- retrieveCommitMessage commitIsPR commitSHA
-    if (optListMisses || optAction == Just BumpVersions)
+    if optListMisses
       then plainDealWithEntry Commit{..} changelogChangelog
       else interactiveDealWithEntry gitRemoteUrl Commit{..} changelogChangelog

--- a/src/Changelogged/Changelog/Check.hs
+++ b/src/Changelogged/Changelog/Check.hs
@@ -42,10 +42,8 @@ checkChangelog gitInfo@GitInfo{..} config@ChangelogConfig{..} = do
   if and flags
     then success $ showPath changelogChangelog <> " is up to date.\n"
                    <> "You can edit it manually now and arrange levels of changes if not yet.\n"
-                   <> "To bump versions run changelogged bump-versions."
     else warning $ showPath changelogChangelog <> " does not mention all git history entries.\n"
-                   <> "You can run changelogged to update it interactively.\n"
-                   <> "Or you are still allowed to keep them missing and bump versions."
+                   <> "You can run changelogged to update it interactively and bump versions.\n"
 
 dealWithCommit :: GitInfo -> ChangelogConfig -> SHA1 -> Appl Bool
 dealWithCommit GitInfo{..} ChangelogConfig{..} commitSHA = do

--- a/src/Changelogged/Common/Types/Common.hs
+++ b/src/Changelogged/Common/Types/Common.hs
@@ -25,9 +25,5 @@ data Commit = Commit
 data Level = App | Major | Minor | Fix | Doc
   deriving (Generic, Show, Enum, Bounded, ToJSON)
 
--- |Available altenative actions
-data Action = BumpVersions
-  deriving (Generic, Eq, Show, Enum, Bounded, ToJSON)
-
 data Interaction = Write | Expand | Skip | Remind | IgnoreAlways
   deriving (Generic, Eq, Show, Enum, Bounded, ToJSON)

--- a/src/Changelogged/Common/Types/Config.hs
+++ b/src/Changelogged/Common/Types/Config.hs
@@ -9,9 +9,10 @@ import qualified Filesystem.Path.CurrentOS        as Path
 import           Changelogged.Common.Types.Common
 
 data Config = Config
-  { configChangelogs  :: [ChangelogConfig]
-  , configBranch      :: Maybe Text
-  , configEntryFormat :: Maybe EntryFormat
+  { configChangelogs    :: [ChangelogConfig]
+  , configBranch        :: Maybe Text
+  , configEntryFormat   :: Maybe EntryFormat
+  , configEditorCommand :: Maybe Text
   } deriving (Eq, Show, Generic)
 
 data LevelHeaders = LevelHeaders

--- a/src/Changelogged/Common/Types/Options.hs
+++ b/src/Changelogged/Common/Types/Options.hs
@@ -4,18 +4,12 @@ module Changelogged.Common.Types.Options where
 import           Data.Text                        (Text)
 import           GHC.Generics                     (Generic)
 
-import           Changelogged.Common.Types.Common
-
 import qualified Filesystem.Path.CurrentOS        as Path
 
 -- | Command line options for @changelogged@.
 data Options = Options
-  { -- | Command to execute.
-    optAction          :: Maybe Action
-    -- | Level of changes (to override one inferred from changelogs).
-  , optChangeLevel     :: Maybe Level
-    -- | Only display report on changelog misses.
-  , optListMisses      :: Bool
+  { -- | Only display report on changelog misses.
+    optListMisses      :: Bool
     -- | Check changelogs from specified version tag or from the very start.
   , optFromVersion     :: Maybe (Maybe Text)
     -- | Print all texts in standard terminal color.

--- a/src/Changelogged/Common/Utils/Pure.hs
+++ b/src/Changelogged/Common/Utils/Pure.hs
@@ -3,6 +3,7 @@ module Changelogged.Common.Utils.Pure where
 
 import           Data.Aeson
 
+import           Data.Monoid                      ((<>))
 import           Data.Maybe                       (fromMaybe)
 import           Data.Text                        (Text)
 import qualified Data.Text                        as Text
@@ -18,6 +19,26 @@ import Changelogged.Common.Types.Config
 
 changeloggedVersion :: Version
 changeloggedVersion = Version "0.3.0"
+
+prettyPossibleValues :: Show a => [a] -> String
+prettyPossibleValues xs = case reverse xs of
+  []  -> "none"
+  [y] -> prettyValue y
+  (y:ys) -> intercalate ", " (map prettyValue (reverse ys)) <> " or " <> prettyValue y
+  where
+    prettyValue v = "'" <> hyphenate (show v) <> "'"
+
+-- |
+-- >>> availableLevels
+-- [App,Major,Minor,Fix,Doc]
+availableLevels :: [Level]
+availableLevels = [minBound..maxBound]
+
+-- |
+-- >>> availableLevelsStr
+-- "'app', 'major', 'minor', 'fix' or 'doc'"
+availableLevelsStr :: String
+availableLevelsStr = prettyPossibleValues availableLevels
 
 -- | Maximum in list ordered by length.
 maxByLen :: [Text] -> Maybe Text

--- a/src/Changelogged/Config.hs
+++ b/src/Changelogged/Config.hs
@@ -25,6 +25,7 @@ defaultConfig = Config
       }
   , configBranch = Nothing
   , configEntryFormat = Nothing
+  , configEditorCommand = Just "vim"
   }
 
 addCommitMessageToIgnored :: Text -> Turtle.FilePath -> Appl ()
@@ -53,6 +54,7 @@ ppConfig :: Config -> Text
 ppConfig Config{..} = mconcat
   [ "Main branch (with version tags)" ?: configBranch
   , "Format of inferred changelog entries" ?: (getEntryFormat <$> configEntryFormat)
+  , "Preferred editor" ?: configEditorCommand
   , "Changelogs" !: formatItems Turtle.fp (map changelogChangelog configChangelogs)
   ]
   where

--- a/src/Changelogged/EntryPoint.hs
+++ b/src/Changelogged/EntryPoint.hs
@@ -44,9 +44,7 @@ processChangelog gitInfo config@ChangelogConfig{..} = do
     touch changelogChangelog
   
   checkChangelog gitInfo config
-  case optAction of
-    Just BumpVersions -> bumpVersions config
-    Nothing -> return ()
+  bumpVersions config
 
 -- | Extract latest history and origin link from git through temporary file and store it in 'GitInfo'.
 loadGitInfo

--- a/src/Changelogged/EntryPoint.hs
+++ b/src/Changelogged/EntryPoint.hs
@@ -7,13 +7,20 @@ module Changelogged.EntryPoint
   , ppGitInfo
   ) where
 
+import           Control.Monad                (unless)
+
+import qualified System.Process               as Proc
+
 import           Prelude                      hiding (FilePath)
 import           Turtle                       hiding (find)
 
 import           Data.Char                    (isDigit)
 import           Data.List                    (find)
 import           Data.Maybe                   (fromMaybe)
+import           Data.String.Conversions      (cs)
 import qualified Data.Text                    as Text
+
+import           Filesystem.Path.CurrentOS    (encodeString)
 
 import           Changelogged.Changelog.Check
 import           Changelogged.Common
@@ -37,6 +44,7 @@ processChangelogs gitInfo = do
 processChangelog :: GitInfo -> ChangelogConfig -> Appl ()
 processChangelog gitInfo config@ChangelogConfig{..} = do
   Options{..} <- gets envOptions
+  editorCommand <- gets (configEditorCommand . envConfig)
   liftIO $ putStrLn ""
   changelogExists <- testfile changelogChangelog
   when (not changelogExists) $ do
@@ -44,7 +52,33 @@ processChangelog gitInfo config@ChangelogConfig{..} = do
     touch changelogChangelog
   
   checkChangelog gitInfo config
-  bumpVersions config
+  enableEditor editorCommand changelogChangelog
+  unless optListMisses $ bumpVersions config
+
+enableEditor :: Maybe Text -> FilePath -> Appl ()
+enableEditor cmd file = do
+  let editorCmd =
+        case cmd of
+          Nothing -> "vim"
+          Just ed -> ed
+  (_,_,_,waiter) <- liftIO $ Proc.createProcess Proc.CreateProcess
+    { Proc.cmdspec = (Proc.ShellCommand (cs editorCmd <> " " <> encodeString file))
+    , Proc.cwd = Nothing
+    , Proc.env = Nothing
+    , Proc.std_in = Proc.Inherit
+    , Proc.std_out = Proc.Inherit
+    , Proc.std_err = Proc.Inherit
+    , Proc.close_fds = True
+    , Proc.create_group = False
+    , Proc.delegate_ctlc = True
+    , Proc.detach_console = True
+    , Proc.create_new_console = True
+    , Proc.new_session = True
+    , Proc.child_group = Nothing
+    , Proc.child_user = Nothing
+    , Proc.use_process_jobs = False
+    }
+  void . liftIO . Proc.waitForProcess $ waiter
 
 -- | Extract latest history and origin link from git through temporary file and store it in 'GitInfo'.
 loadGitInfo


### PR DESCRIPTION
`changelogged` with good configuration file will do all the things.
In the middle it will run text editor to edit changelogs.
Alternative to #138 (Closes #138 ).
Closes #120 
Closes #128 