### PR TITLE
Split changelogged to subcommands

### DIFF
--- a/src/Changelogged/Aeson.hs
+++ b/src/Changelogged/Aeson.hs
@@ -25,6 +25,9 @@ instance FromJSON EntryFormat where
 instance ToJSON EntryFormat where
   toJSON = toJSON . getEntryFormat
 
+deriving instance ToJSON CommonOptions
+deriving instance ToJSON ChangelogOptions
+deriving instance ToJSON VersionOptions
 deriving instance ToJSON Options
 
 deriveJSON (jsonDerivingModifier "VersionPattern") ''VersionPattern

--- a/src/Changelogged/Changelog/Interactive.hs
+++ b/src/Changelogged/Changelog/Interactive.hs
@@ -57,7 +57,6 @@ interactiveSession :: Text -> Link -> Commit -> FilePath -> Appl ()
 interactiveSession entryPrefix repoUrl commit@Commit{..} changelog = do
   suggestMissing entryPrefix repoUrl commit
   action <- prompt
-  Options{..} <- gets envOptions
   case action of
     Write -> addMissing entryPrefix repoUrl commit changelog
     Expand -> do
@@ -78,7 +77,7 @@ interactiveDealWithEntry repoUrl commit@Commit{..} changelog =
 -- |
 suggestMissing :: Text -> Link -> Commit -> Appl ()
 suggestMissing entryPrefix gitUrl Commit{..} = do
-  (ChangeloggedEnv Options{..} Config{..}) <- get
+  Config{..} <- gets envConfig
   case commitIsPR of
     Just num ->
       printEntry (EntryFormat entryPrefix <> fromMaybe defaultEntryFormat configEntryFormat) commitMessage (prLink gitUrl num) (getPR num)
@@ -90,7 +89,7 @@ addMissing :: Text -> Link -> Commit -> FilePath -> Appl ()
 addMissing entryPrefix gitUrl Commit{..} changelog = do
   currentLogs <- fold (input changelog) Fold.list
   (ChangeloggedEnv Options{..} Config{..}) <- get
-  unless optDryRun $ do
+  unless (optDryRun optionsCommon) $ do
     output changelog (return $ unsafeTextToLine (entry configEntryFormat))
     tagm <- getCommitTag commitSHA
     case tagm of

--- a/src/Changelogged/Common/Types.hs
+++ b/src/Changelogged/Common/Types.hs
@@ -21,12 +21,12 @@ import           Changelogged.Common.Types.Git
 import           Changelogged.Common.Types.Options
 
 data ChangeloggedEnv = ChangeloggedEnv
-  { envOptions :: Options
-  , envConfig  :: Config
+  { envOptions    :: Options
+  , envConfig     :: Config
   } deriving Show
 
 newtype Appl a = Appl { runAppl :: StateT ChangeloggedEnv IO a }
   deriving newtype (Functor, Applicative, Monad, MonadState ChangeloggedEnv, MonadIO, MonadBase IO, MonadThrow, MonadCatch)
 
-runInAppl :: Options -> Config -> Appl a -> IO a
-runInAppl opts cfg r = evalStateT (runAppl r) (ChangeloggedEnv opts cfg)
+runInAppl :: ChangeloggedEnv -> Appl a -> IO a
+runInAppl env r = evalStateT (runAppl r) env

--- a/src/Changelogged/Common/Types/Common.hs
+++ b/src/Changelogged/Common/Types/Common.hs
@@ -22,7 +22,7 @@ data Commit = Commit
   } deriving (Eq, Show)
 
 -- |Level of changes to bump to.
-data Level = App | Major | Minor | Fix | Doc
+data Level = Application | Major | Minor | Fix | Doc
   deriving (Generic, Show, Enum, Bounded, ToJSON)
 
 -- |Available altenative actions

--- a/src/Changelogged/Common/Types/Options.hs
+++ b/src/Changelogged/Common/Types/Options.hs
@@ -8,18 +8,15 @@ import           Changelogged.Common.Types.Common
 
 import qualified Filesystem.Path.CurrentOS        as Path
 
--- | Command line options for @changelogged@.
 data Options = Options
-  { -- | Command to execute.
-    optAction          :: Maybe Action
-    -- | Level of changes (to override one inferred from changelogs).
-  , optChangeLevel     :: Maybe Level
-    -- | Only display report on changelog misses.
-  , optListMisses      :: Bool
-    -- | Check changelogs from specified version tag or from the very start.
-  , optFromVersion     :: Maybe (Maybe Text)
-    -- | Print all texts in standard terminal color.
-  , optNoColors        :: Bool
+  { optionsCmd    :: Either ChangelogOptions VersionOptions
+  , optionsCommon :: CommonOptions
+  } deriving (Generic, Show)
+
+-- | Command line options for @changelogged@.
+data CommonOptions = CommonOptions
+  { -- | Print all texts in standard terminal color.
+    optNoColors        :: Bool
     -- | Run avoiding changes in files.
   , optDryRun          :: Bool
     -- | Check exactly one target changelog.
@@ -30,4 +27,18 @@ data Options = Options
   , optVerbose         :: Bool
     -- | Print version.
   , optVersion         :: Bool
+  } deriving (Generic, Show)
+
+-- | Command line options for @changelogged@.
+data ChangelogOptions = ChangelogOptions
+  { -- | Only display report on changelog misses.
+    optListMisses      :: Bool
+    -- | Check changelogs from specified version tag or from the very start.
+  , optFromVersion     :: Maybe (Maybe Text)
+  } deriving (Generic, Show)
+
+-- | Command line options for @changelogged@.
+data VersionOptions = VersionOptions
+  { -- | Level of changes (to override one inferred from changelogs).
+    optChangeLevel     :: Maybe Level
   } deriving (Generic, Show)

--- a/src/Changelogged/Common/Utils/IO.hs
+++ b/src/Changelogged/Common/Utils/IO.hs
@@ -30,7 +30,7 @@ coloredPrintIO noColor color line = if noColor
 -- |Print '@text@' with ansi-terminal color.
 coloredPrint :: Color -> Text -> Appl ()
 coloredPrint color line = do
-  noColor <- gets (optNoColors . envOptions)
+  noColor <- gets (optNoColors . optionsCommon . envOptions)
   liftIO $ coloredPrintIO noColor color line
 
 success :: Text -> Appl ()
@@ -51,7 +51,7 @@ info msg = coloredPrint Cyan $
 
 debug :: Text -> Appl ()
 debug msg = do
-  verbose <- gets (optVerbose . envOptions)
+  verbose <- gets (optVerbose . optionsCommon . envOptions)
   when verbose $ do
     coloredPrint Magenta $
       "DEBUG: " <> msg <> "\n"

--- a/src/Changelogged/Common/Utils/Pure.hs
+++ b/src/Changelogged/Common/Utils/Pure.hs
@@ -45,7 +45,7 @@ delimited ver = tuplify $ map (read . Text.unpack) (Text.split (=='.') ver)
 
 bump :: (Int, Int, Int, Int, Int) -> Level -> Text
 bump (app, major, minor, fix, doc) lev = Text.intercalate "." $ map showText $ case lev of
-  App   -> [app + 1, 0]
+  Application   -> [app + 1, 0]
   Major -> [app, major + 1, 0]
   Minor -> [app, major, minor + 1, 0]
   Fix   -> [app, major, minor, fix + 1, 0]

--- a/src/Changelogged/Config.hs
+++ b/src/Changelogged/Config.hs
@@ -30,7 +30,7 @@ defaultConfig = Config
 addCommitMessageToIgnored :: Text -> Turtle.FilePath -> Appl ()
 addCommitMessageToIgnored message changelog = do
   ChangeloggedEnv opts@Options{..} cfg'@Config{..} <- get
-  let configPath = fromMaybe ".changelogged.yaml" (Text.unpack . showPath <$> optConfigPath)
+  let configPath = fromMaybe ".changelogged.yaml" (Text.unpack . showPath <$> (optConfigPath optionsCommon))
       newIgnoreCommits cc = Just [message] <> changelogIgnoreCommits cc
       replaceElem =
         (\(first, as) -> first <> ((head as) {changelogIgnoreCommits = newIgnoreCommits (head as)}: tail as))

--- a/src/Changelogged/EntryPoint.hs
+++ b/src/Changelogged/EntryPoint.hs
@@ -23,7 +23,7 @@ import           Changelogged.Versions.Bump
 processChangelogs :: GitInfo -> Appl ()
 processChangelogs gitInfo = do
   (ChangeloggedEnv Options{..} Config{..}) <- get
-  case optTargetChangelog of
+  case (optTargetChangelog optionsCommon) of
     Nothing -> if null configChangelogs
       then failure "You have empty configuration file"
       else mapM_ (processChangelog gitInfo) configChangelogs
@@ -36,7 +36,8 @@ processChangelogs gitInfo = do
 
 processChangelog :: GitInfo -> ChangelogConfig -> Appl ()
 processChangelog gitInfo config@ChangelogConfig{..} = do
-  Options{..} <- gets envOptions
+  CommonOptions{..} <- gets (optionsCommon . envOptions)
+  cmdOpts <- gets (optionsCmd . envOptions)
   liftIO $ putStrLn ""
   changelogExists <- testfile changelogChangelog
   when (not changelogExists) $ do
@@ -44,20 +45,23 @@ processChangelog gitInfo config@ChangelogConfig{..} = do
     touch changelogChangelog
   
   checkChangelog gitInfo config
-  case optAction of
-    Just BumpVersions -> bumpVersions config
-    Nothing -> return ()
+  case cmdOpts of
+    Right _ -> bumpVersions config
+    Left _ -> return ()
 
 -- | Extract latest history and origin link from git through temporary file and store it in 'GitInfo'.
 loadGitInfo
   :: Maybe Text -- ^ Branch with version tags (@HEAD@ is used by default).
   -> Appl GitInfo
 loadGitInfo branch = do
-  fromTag      <- gets (optFromVersion . envOptions)
+  cmdOpts <- gets (optionsCmd . envOptions)
   latestTag    <- loadGitLatestTag branch
-  gitHistory   <- loadGitHistory (case fromTag of
-    Nothing -> latestTag
-    Just tag -> tag)
+  gitHistory   <- case cmdOpts of
+    Left ChangelogOptions{..} -> case optFromVersion of
+      Nothing -> loadGitHistory latestTag
+      Just tag -> printf ("Checking changelogs from "%s%"\n") (ppTag tag) >> loadGitHistory tag
+    Right _ -> loadGitHistory latestTag
+  
   gitRemoteUrl <- loadGitRemoteUrl
   let gitLatestVersion = extractVersion latestTag
   return GitInfo {..}
@@ -65,6 +69,10 @@ loadGitInfo branch = do
     extractVersion tag = case Text.dropWhile (not . isDigit) <$> tag of
       Just ver | not (Text.null ver) -> Just ver
       _                              -> Nothing
+
+ppTag :: Maybe Text -> Text
+ppTag Nothing = "start of the project"
+ppTag (Just tag) = tag
 
 -- | Pretty print known information about a Git project.
 ppGitInfo :: GitInfo -> Text

--- a/src/Changelogged/Git.hs
+++ b/src/Changelogged/Git.hs
@@ -113,7 +113,7 @@ showDiff (SHA1 sha) = do
   --stdout $ inproc "git" args empty
   where
     buildArgs = do
-      noColor <- gets (optNoColors . envOptions)
+      noColor <- gets (optNoColors . optionsCommon . envOptions)
       return . map cs $ if noColor
         then ["show", "--minimal", "--color=never", sha]
         else ["show", "--minimal", "--color=always", sha]

--- a/src/Changelogged/Options.hs
+++ b/src/Changelogged/Options.hs
@@ -25,13 +25,13 @@ import           Changelogged.Common.Utils.Pure
 
 -- |
 -- >>> availableLevels
--- [App,Major,Minor,Fix,Doc]
+-- [Application,Major,Minor,Fix,Doc]
 availableLevels :: [Level]
 availableLevels = [minBound..maxBound]
 
 -- |
 -- >>> availableLevelsStr
--- "'app', 'major', 'minor', 'fix' or 'doc'"
+-- "'application', 'major', 'minor', 'fix' or 'doc'"
 availableLevelsStr :: String
 availableLevelsStr = prettyPossibleValues availableLevels
 

--- a/src/Changelogged/Versions/Bump.hs
+++ b/src/Changelogged/Versions/Bump.hs
@@ -67,7 +67,7 @@ generateVersionByChangelog logConfig@ChangelogConfig{..} = do
 
 bumpVersions :: ChangelogConfig -> Appl ()
 bumpVersions config@ChangelogConfig{..} = flip catch (\(ex :: PatternMatchFail) -> failure (showText ex)) $ do
-  Options{..} <- gets envOptions
+  Right VersionOptions{..} <- gets (optionsCmd . envOptions)
   do
     newVersion <- case optChangeLevel of
       Just lev -> generateVersion lev config

--- a/src/Changelogged/Versions/Utils.hs
+++ b/src/Changelogged/Versions/Utils.hs
@@ -18,7 +18,7 @@ import           Changelogged.Pattern
 
 -- |Add version label to changelog.
 headChangelog :: Version -> FilePath -> Appl ()
-headChangelog (Version version) changelog = gets (optDryRun . envOptions) >>= (\dry -> unless dry $ do
+headChangelog (Version version) changelog = gets (optDryRun . optionsCommon . envOptions) >>= (\dry -> unless dry $ do
   currentLogs <- fold (input changelog) Fold.list
   output changelog (return $ unsafeTextToLine version)
   append changelog "---"
@@ -63,7 +63,7 @@ generateVersionedFile file (new:news) (old:olds) = generateVersionedFile (replac
 bumpPart :: Version -> VersionFile -> Appl ()
 bumpPart version file@VersionFile{..} = do
   printf ("- Updating version for "%fp%"\n") versionFilePath
-  dryRun <- gets (optDryRun . envOptions)
+  dryRun <- gets (optDryRun . optionsCommon . envOptions)
   unless dryRun $ sh $ bumpAny file version
 
 -- |Get level of changes from changelog.


### PR DESCRIPTION
Introduces `run` and `bump-versions` proper subcommands with their own sets of options.
`--level` becomes argument of `bump-versions`.
When to edit changelogs is on user's decision.
Alternative to #137 (Closes #137 )
Closes #120 
Closes #128 