### PR TITLE
Fix a bit and separate functions depending on git hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ changelogged
 ```
 
 After you refuse to do to interactive mode it will add missing entries to your changelogs and open editor for each if them.
+
+By default editor is set by `$EDITOR` variable.
+
 After you can bummp versions over whole project (usable if you have more than one version file).
 
 That's it! Now you have a proper changelog with no forgotten changes.

--- a/src/Changelogged/Changelog/Check.hs
+++ b/src/Changelogged/Changelog/Check.hs
@@ -16,7 +16,7 @@ import           Changelogged.Changelog.Interactive
 import           Changelogged.Changelog.Dry
 import           Changelogged.Common
 import           Changelogged.Pattern
-import           Changelogged.Git (retrieveCommitMessage)
+import           Changelogged.Git (retrieveCommitMessage, parseHostingType)
 
 checkChangelog :: GitInfo -> ChangelogConfig -> Appl ()
 checkChangelog gitInfo@GitInfo{..} config@ChangelogConfig{..} = do
@@ -50,6 +50,7 @@ checkChangelog gitInfo@GitInfo{..} config@ChangelogConfig{..} = do
 
 extractCommitMetadata :: GitInfo -> ChangelogConfig -> SHA1 -> Appl (Maybe Commit)
 extractCommitMetadata GitInfo{..} ChangelogConfig{..} commitSHA = do
+  let hosting = parseHostingType gitRemoteUrl
   ignoreChangeReasoned <- sequence $
     [ commitNotWatched changelogWatchFiles commitSHA
     , allFilesIgnored changelogIgnoreFiles commitSHA
@@ -58,7 +59,7 @@ extractCommitMetadata GitInfo{..} ChangelogConfig{..} commitSHA = do
     then return Nothing 
     else do
       -- FIXME: impossible.
-      commitIsPR <- fmap (PR . fromJustCustom "Cannot find commit hash in git log entry" . githubRefMatch . lineToText) <$>
-          fold (grep githubRefGrep (grep (has (text (getSHA1 commitSHA))) (select gitHistory))) Fold.head
+      commitIsPR <- fmap (PR . fromJustCustom "Cannot find commit hash in git log entry" . refMatch hosting . lineToText) <$>
+          fold (grep (refGrep hosting) (grep (has (text (getSHA1 commitSHA))) (select gitHistory))) Fold.head
       commitMessage <- retrieveCommitMessage commitIsPR commitSHA
       return $ Just Commit{..}

--- a/src/Changelogged/Changelog/Check.hs
+++ b/src/Changelogged/Changelog/Check.hs
@@ -45,7 +45,7 @@ checkChangelog gitInfo@GitInfo{..} config@ChangelogConfig{..} = do
               then interactiveWalk gitRemoteUrl changelogChangelog 
               else simpleWalk gitRemoteUrl changelogChangelog) $
             checkableCommits
-      success $ showPath changelogChangelog <> " is updated.\n"
+      success $ showPath changelogChangelog <> " is updated.\nTrying to run editor."
 
 extractCommitMetadata :: GitInfo -> ChangelogConfig -> SHA1 -> Appl (Maybe Commit)
 extractCommitMetadata GitInfo{..} ChangelogConfig{..} commitSHA = do

--- a/src/Changelogged/Changelog/Check.hs
+++ b/src/Changelogged/Changelog/Check.hs
@@ -46,7 +46,6 @@ checkChangelog gitInfo@GitInfo{..} config@ChangelogConfig{..} = do
               else simpleWalk gitRemoteUrl changelogChangelog) $
             checkableCommits
       success $ showPath changelogChangelog <> " is updated.\n"
-                   <> "You can edit it manually now.\n"
 
 extractCommitMetadata :: GitInfo -> ChangelogConfig -> SHA1 -> Appl (Maybe Commit)
 extractCommitMetadata GitInfo{..} ChangelogConfig{..} commitSHA = do

--- a/src/Changelogged/Changelog/Interactive.hs
+++ b/src/Changelogged/Changelog/Interactive.hs
@@ -5,6 +5,7 @@ module Changelogged.Changelog.Interactive where
 import           Prelude              hiding (FilePath)
 import           Turtle               hiding (stdout)
 
+import           Control.Monad        (when)
 import qualified Control.Foldl        as Fold
 
 import           Data.Maybe           (fromMaybe, isJust)
@@ -23,38 +24,38 @@ import           Changelogged.Pattern (isMerge)
 -- >>> :set -XOverloadedStrings
 
 -- It cannot be folded since we have 'Remind' option.
-interactiveSession :: Appl Interaction -> Text -> Link -> FilePath -> [Commit] -> Appl ()
-interactiveSession _ _ _ _ [] = return ()
-interactiveSession prompt entryPrefix repoUrl changelog (current@Commit{..}:rest) = do
-  suggestMissing entryPrefix repoUrl current
+interactiveSession :: Appl Interaction -> Bool -> Text -> Link -> FilePath -> [Commit] -> Appl ()
+interactiveSession _ _ _ _ _ [] = return ()
+interactiveSession prompt printSug entryPrefix repoUrl changelog (current@Commit{..}:rest) = do
+  when printSug $ suggestMissing entryPrefix repoUrl current
   action <- prompt
   Options{..} <- gets envOptions
   case action of
     Write -> do
       addMissing entryPrefix repoUrl current changelog
-      interactiveSession prompt entryPrefix repoUrl changelog rest
+      interactiveSession prompt printSug entryPrefix repoUrl changelog rest
     Expand -> do
       addMissing entryPrefix repoUrl current changelog
       if (isMerge commitMessage || isJust commitIsPR) 
         then do
           subChanges <- listPRCommits commitSHA repoUrl
-          interactiveSession prompt ("  " <> entryPrefix) repoUrl changelog subChanges
+          interactiveSession prompt printSug ("  " <> entryPrefix) repoUrl changelog subChanges
         else return ()
-      interactiveSession prompt entryPrefix repoUrl changelog rest
-    Skip -> interactiveSession prompt entryPrefix repoUrl changelog rest
-    Remind -> showDiff commitSHA >> interactiveSession prompt "" repoUrl changelog (current:rest)
+      interactiveSession prompt printSug entryPrefix repoUrl changelog rest
+    Skip -> interactiveSession prompt printSug entryPrefix repoUrl changelog rest
+    Remind -> showDiff commitSHA >> interactiveSession prompt printSug "" repoUrl changelog (current:rest)
     IgnoreAlways -> do
       debug (showText changelog)
       addCommitToIgnored commitSHA changelog
-      interactiveSession prompt entryPrefix repoUrl changelog rest
-    Quit -> interactiveSession promptSkip "" repoUrl changelog rest
-    WriteRest -> interactiveSession promptSimple "" repoUrl changelog (current:rest)
+      interactiveSession prompt printSug entryPrefix repoUrl changelog rest
+    Quit -> interactiveSession promptSkip False "" repoUrl changelog rest
+    WriteRest -> interactiveSession promptSimple False "" repoUrl changelog (current:rest)
 
 interactiveWalk :: Link -> FilePath -> [Commit] -> Appl ()
-interactiveWalk = interactiveSession promptInteractive ""
+interactiveWalk = interactiveSession promptInteractive True ""
 
 simpleWalk :: Link -> FilePath -> [Commit] -> Appl ()
-simpleWalk = interactiveSession promptSimple ""
+simpleWalk = interactiveSession promptSimple False ""
 
 -- |
 suggestMissing :: Text -> Link -> Commit -> Appl ()

--- a/src/Changelogged/Changelog/Interactive.hs
+++ b/src/Changelogged/Changelog/Interactive.hs
@@ -37,7 +37,7 @@ interactiveSession prompt entryPrefix repoUrl changelog (current@Commit{..}:rest
       addMissing entryPrefix repoUrl current changelog
       if (isMerge commitMessage || isJust commitIsPR) 
         then do
-          subChanges <- listPRCommits commitSHA
+          subChanges <- listPRCommits commitSHA repoUrl
           interactiveSession prompt ("  " <> entryPrefix) repoUrl changelog subChanges
         else return ()
       interactiveSession prompt entryPrefix repoUrl changelog rest

--- a/src/Changelogged/Common/Types/Common.hs
+++ b/src/Changelogged/Common/Types/Common.hs
@@ -27,6 +27,9 @@ data Commit = Commit
 data Level = App | Major | Minor | Fix | Doc
   deriving (Generic, Show, Enum, Bounded, ToJSON)
 
+data GitHosting = GitHub | BitBucket | GitLab
+  deriving (Generic, Show, Enum, Bounded, ToJSON)
+
 showHumanReadableLevel :: Level -> Text
 showHumanReadableLevel App = "application level changes"
 showHumanReadableLevel Major = "major changes"

--- a/src/Changelogged/Config.hs
+++ b/src/Changelogged/Config.hs
@@ -24,7 +24,7 @@ defaultConfig = Config
       }
   , configBranch = Nothing
   , configEntryFormat = Nothing
-  , configEditorCommand = Just "vim"
+  , configEditorCommand = Just "$EDITOR"
   }
 
 addCommitToIgnored :: SHA1 -> Turtle.FilePath -> Appl ()

--- a/src/Changelogged/Pattern.hs
+++ b/src/Changelogged/Pattern.hs
@@ -74,10 +74,19 @@ githubRefRegex = has $ "#" <> plus digit
 githubRefGrep :: Pattern Text
 githubRefGrep = has (text "pull request #")
 
--- >>> githubRefMatch "text #444 text"
+--FIXME: add regexps for Gitlab and Bitbucket.
+
+refGrep :: GitHosting -> Pattern Text
+refGrep GitHub = githubRefGrep
+refGrep GitLab = githubRefGrep
+refGrep BitBucket = githubRefGrep
+
+-- >>> refMatch GitHub "text #444 text"
 -- Just "#444"
-githubRefMatch :: Text -> Maybe Text
-githubRefMatch str = maxByLen $ match githubRefRegex str
+refMatch :: GitHosting -> Text -> Maybe Text
+refMatch GitHub str = maxByLen $ match githubRefRegex str
+refMatch GitLab str = maxByLen $ match githubRefRegex str
+refMatch BitBucket str = maxByLen $ match githubRefRegex str
 
 -- >>> isMerge "Merge branch 'release-v1.0'"
 -- True


### PR DESCRIPTION
Eases #58 and #73 
Now only marked with `FIXME` functions in Pattern and Git modules are subject to change while implementing it.
And maybe variable names.